### PR TITLE
Fix nightly warnings related to lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ extern {
 }
 
 /// Types that may be used as the arguments to an Objective-C block.
-pub trait BlockArguments {
+pub trait BlockArguments: Sized {
     /// Calls the given `Block` with self as the arguments.
     ///
     /// Unsafe because `block` must point to a valid `Block` and this invokes
@@ -179,7 +179,7 @@ impl<A, R> Drop for RcBlock<A, R> {
 }
 
 /// Types that may be converted into a `ConcreteBlock`.
-pub trait IntoConcreteBlock<A> where A: BlockArguments {
+pub trait IntoConcreteBlock<A>: Sized where A: BlockArguments {
     /// The return type of the resulting `ConcreteBlock`.
     type Ret;
 


### PR DESCRIPTION
The following warnings appear:

```
src/lib.rs:73:5: 73:68 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:73     unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:73:5: 73:68 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:73:5: 73:68 note: `Self` does not have a constant size known at compile-time
src/lib.rs:73     unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:73:5: 73:68 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:73     unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:73:5: 73:68 note: required by `Block`
src/lib.rs:73     unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R;
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:187:5: 187:71 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/lib.rs:187     fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:187:5: 187:71 help: run `rustc --explain E0277` to see a detailed explanation
src/lib.rs:187:5: 187:71 note: `Self` does not have a constant size known at compile-time
src/lib.rs:187     fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:187:5: 187:71 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/lib.rs:187     fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:187:5: 187:71 note: required by `ConcreteBlock`
src/lib.rs:187     fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

...because of:

https://github.com/rust-lang/rfcs/pull/1214