### PR TITLE
Support for using the GNUstep blocks runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ exclude = [".gitignore"]
 [dependencies]
 libc = "0.1"
 
+[features]
+gnustep_runtime = []
+
 [dev-dependencies.objc_test_utils]
 version = "0.0"
 path = "test_utils"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 use libc::{c_int, c_ulong, c_void};
 
-#[link(name = "System", kind = "dylib")]
+#[cfg_attr(not(feature = "gnustep_runtime"),link(name = "System", kind = "dylib"))]
+#[cfg_attr(feature ="gnustep_runtime",link(name = "objc", kind = "dylib"))]
 extern {
     static _NSConcreteStackBlock: ();
 

--- a/test_utils/block_utils.c
+++ b/test_utils/block_utils.c
@@ -1,5 +1,9 @@
 #include <stdint.h>
+#if __has_include("Block.h")
 #include <Block.h>
+#elif __has_include("objc/blocks_runtime.h")
+#include <objc/blocks_runtime.h>
+#endif
 
 typedef int32_t (^IntBlock)();
 typedef int32_t (^AddBlock)(int32_t);

--- a/test_utils/build.rs
+++ b/test_utils/build.rs
@@ -1,5 +1,5 @@
 extern crate gcc;
 
 fn main() {
-    gcc::compile_library("libblock_utils.a", &["block_utils.c"]);
+    gcc::Config::new().file("block_utils.c").flag("-fblocks").compile("libblock_utils.a");
 }


### PR DESCRIPTION
Hi!

Another pull request for better support for non-Apple OSes. This adds support for linking against the GNUstep blocks runtime.