### PR TITLE
Fix markdown warning.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 A Rust interface for Objective-C blocks.
 
 For more information on the specifics of the block implementation, see
-Clang's documentation: http://clang.llvm.org/docs/Block-ABI-Apple.html
+Clang's documentation: <http://clang.llvm.org/docs/Block-ABI-Apple.html>
 
 # Invoking blocks
 


### PR DESCRIPTION
When updating to current Rust, there is a warning for a change
in the output due to the change in Markdown implementations:

```
WARNING: documentation for this crate may be rendered differently using the new Pulldown renderer.
    See https://github.com/rust-lang/rust/issues/44229 for details.
WARNING: rendering difference in `A Rust interface for Objective-C blocks.`
   --> src/lib.rs:1:0
    /html[0]/body[0]/p[1] Text differs:
        expected: `... http://clang.llvm.org/docs/Block-ABI-Apple.html`
        found:    `...`
WARNING: rendering difference in `A Rust interface for Objective-C blocks.`
   --> src/lib.rs:1:0
    /html[0]/body[0]/p[1] Unexpected element `a`: found: `<a href="http://clang.llvm.org/docs/Block-ABI-Appl ... k-ABI-Apple.html</a>`
    Finished dev [unoptimized + debuginfo] target(s) in 0.59 secs
```
