### PR TITLE
Update test_utils to use `cc` rather than `gcc`.

### DIFF
--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -15,4 +15,4 @@ name = "objc_test_utils"
 path = "lib.rs"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1"

--- a/test_utils/build.rs
+++ b/test_utils/build.rs
@@ -1,7 +1,7 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    gcc::Config::new()
+    cc::Build::new()
         .compiler("clang")
         .file("block_utils.c")
         .flag("-fblocks")


### PR DESCRIPTION
The `gcc` crate has been replaced with `cc`. Additionally, the
`gcc:Config` was renamed to `gcc::Build`. This updates both of
those.