### PR TITLE
Minor refactorings + added as_ptr methods.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,12 +155,20 @@ impl<A, R> RcBlock<A, R> {
         let ptr = _Block_copy(ptr as *const c_void) as *mut Block<A, R>;
         Self { ptr }
     }
+
+    pub fn as_ptr(&self) -> *const Block<A,R> {
+        self.ptr
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut Block<A,R> {
+        self.ptr
+    }
 }
 
 impl<A, R> Clone for RcBlock<A, R> {
-    fn clone(&self) -> RcBlock<A, R> {
+    fn clone(&self) -> Self {
         unsafe {
-            RcBlock::copy(self.ptr)
+            Self::copy(self.ptr)
         }
     }
 }
@@ -168,7 +176,7 @@ impl<A, R> Clone for RcBlock<A, R> {
 impl<A, R> Deref for RcBlock<A, R> {
     type Target = Block<A, R>;
 
-    fn deref(&self) -> &Block<A, R> {
+    fn deref(&self) -> &Self::Target {
         unsafe { &*self.ptr }
     }
 }
@@ -327,7 +335,7 @@ struct BlockDescriptor<B> {
 
 impl<B> BlockDescriptor<B> {
     fn new() -> BlockDescriptor<B> {
-        BlockDescriptor {
+        Self {
             _reserved: 0,
             block_size: mem::size_of::<B>() as c_ulong,
             copy_helper: block_context_copy::<B>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl<A, R> RcBlock<A, R> {
     /// reference count or it will be overreleased when the `RcBlock` is
     /// dropped.
     pub unsafe fn new(ptr: *mut Block<A, R>) -> Self {
-        RcBlock { ptr: ptr }
+        Self { ptr }
     }
 
     /// Constructs an `RcBlock` by copying the given block.
@@ -153,7 +153,7 @@ impl<A, R> RcBlock<A, R> {
     /// Unsafe because `ptr` must point to a valid `Block`.
     pub unsafe fn copy(ptr: *mut Block<A, R>) -> Self {
         let ptr = _Block_copy(ptr as *const c_void) as *mut Block<A, R>;
-        RcBlock { ptr: ptr }
+        Self { ptr }
     }
 }
 
@@ -256,7 +256,7 @@ impl<A, R, F> ConcreteBlock<A, R, F> {
     /// correct arguments.
     unsafe fn with_invoke(invoke: unsafe extern fn(*mut Self, ...) -> R,
             closure: F) -> Self {
-        ConcreteBlock {
+        Self {
             base: BlockBase {
                 isa: &_NSConcreteStackBlock,
                 // 1 << 25 = BLOCK_HAS_COPY_DISPOSE
@@ -288,7 +288,7 @@ impl<A, R, F> ConcreteBlock<A, R, F> where F: 'static {
 impl<A, R, F> Clone for ConcreteBlock<A, R, F> where F: Clone {
     fn clone(&self) -> Self {
         unsafe {
-            ConcreteBlock::with_invoke(mem::transmute(self.base.invoke),
+            Self::with_invoke(mem::transmute(self.base.invoke),
                 self.closure.clone())
         }
     }


### PR DESCRIPTION
The point of the as_ptr methods is to make dealing with e.g. a method that sets a nullable block easier. I'm not sure if there is a better way of doing this.

```rust
fn set_block(&self, block: Option<RcBlock<A, B>> {
    let b = if let Some(block) = block {
        block.as_ptr()
    } else {
        nil
    };
    unsafe { msg_send![self, setBlock: b] } 
}
```