### PR TITLE
Narrow the scope of unsafe block for the ConcreteBlock impl 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,15 +273,13 @@ impl<A, R, F> ConcreteBlock<A, R, F> {
 impl<A, R, F> ConcreteBlock<A, R, F> where F: 'static {
     /// Copy self onto the heap as an `RcBlock`.
     pub fn copy(self) -> RcBlock<A, R> {
-        unsafe {
             let mut block = self;
-            let copied = RcBlock::copy(&mut *block);
+            let copied = unsafe { RcBlock::copy(&mut *block) };
             // At this point, our copy helper has been run so the block will
             // be moved to the heap and we can forget the original block
             // because the heap block will drop in our dispose helper.
             mem::forget(block);
             copied
-        }
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 1 function are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the RcBlock::copy() function(these are unsafe function)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 