### PR TITLE
Add apple tvos support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@ use std::ptr;
 
 enum Class { }
 
-#[cfg_attr(any(target_os = "macos", target_os = "ios"),
+#[cfg_attr(any(target_os = "macos", target_os = "ios", target_os = "tvos"),
            link(name = "System", kind = "dylib"))]
-#[cfg_attr(not(any(target_os = "macos", target_os = "ios")),
+#[cfg_attr(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")),
            link(name = "BlocksRuntime", kind = "dylib"))]
 extern {
     static _NSConcreteStackBlock: Class;


### PR DESCRIPTION
This PR allows using rust-block lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64